### PR TITLE
Allow users to use custom text

### DIFF
--- a/src/json-tree.vue
+++ b/src/json-tree.vue
@@ -71,7 +71,8 @@ export default {
     raw: {
       type: String
     },
-    data: {}
+    data: {},
+    displayText: String
   },
 
   data () {
@@ -107,6 +108,7 @@ export default {
 
   methods: {
     format (n) {
+      if (this.displayText) return this.displayText;
       if (n > 1) return `${n} items`
       return n ? '1 item' : 'no items'
     }


### PR DESCRIPTION
User can display custom text instead of default text for the drop down.
eg. instead of `+ { /* 13 items */ }` user can do this  `+ { /* Click to view more */ }`